### PR TITLE
Apply consistent style between current and last cards

### DIFF
--- a/src/adjust_styles.js
+++ b/src/adjust_styles.js
@@ -1,0 +1,100 @@
+/*
+
+adjust_styles.js
+
+Make the appearance of the Last Card table, match the Current Card table
+for a more consistent appearance. The two differ because the latter is
+generated in the add-on while the former comes from an internal web
+service in the Anki application (and modified by scripts that are running
+on the page delivered by that service.)
+
+The strategy here is to allow the Last Card table to be produced, then scrape
+all of its data, create a new table using our format, insert it into the DOM
+then delete the original table.
+
+*/
+
+
+function waitForElementByXPath(path) {
+   // wait for the element specified at the given XPath to be available
+   return new Promise(resolve => {
+      const resType = XPathResult.FIRST_ORDERED_NODE_TYPE;
+      if (document.evaluate(path, document, null, resType, null).singleNodeValue) {
+         return resolve(document.evaluate(path, document, null, resType, null).singleNodeValue);
+      }
+
+      const observer = new MutationObserver(mutations => {
+         if (document.evaluate(path, document, null, resType, null).singleNodeValue) {
+            resolve(document.evaluate(path, document, null, resType, null).singleNodeValue);
+            observer.disconnect();
+         }
+      });
+
+      observer.observe(document.body, {
+         childList: true,
+         subtree: true
+      });
+   });
+}
+
+async function adjustAppearance() {
+   console.log("adjust_styles.js script loaded!");
+
+   // get the last card table and wait about 20ms
+   // this is a little fragile, but seemingly necessary
+   let wait = new Promise((resolve, reject) => {
+      setTimeout(() => resolve(1), 20)
+   });
+   await wait;
+   // get the last card table
+   let targetPath = "//*[contains(@id,'cardinfo-')]/div/div/div/table";
+   const lc_table = await waitForElementByXPath(targetPath)
+
+   // iterate over rows, accumulating headers and data
+   headers = []; data = [];
+   Array.from(lc_table.children).forEach(row => { 
+      const targetHeader = row.querySelector('th');
+      headers.push(targetHeader.textContent);
+
+      const targetCell = row.querySelector('td');
+      data.push(targetCell.textContent);
+   });
+
+   // create new table
+   var newLastCardTable = document.createElement('table');
+   newLastCardTable.style.width = "100%";
+
+   for(let i = 0; i < headers.length; i++) {
+      row = document.createElement('tr');
+      headerCell = document.createElement('td');
+      headerCell.width = "35%";
+      headerCell.align = "left";
+      headerCell.style.paddingRight = "3px";
+      boldHeaderElement = document.createElement('b')
+      boldHeaderElement.textContent = headers[i];
+      headerCell.appendChild(boldHeaderElement);
+      row.appendChild(headerCell);
+
+      dataCell = document.createElement('td');
+      dataCell.textContent = data[i];
+      row.appendChild(dataCell);
+
+      newLastCardTable.appendChild(row);
+   }
+
+   // insert new last card table and remove the old last card table
+   const resType = XPathResult.FIRST_ORDERED_NODE_TYPE;
+   lastCardParentDivPath = "//*[contains(@id,'cardinfo-')]"
+   lastCardParentDiv = document.evaluate(lastCardParentDivPath, document, null, resType, null).singleNodeValue;
+   var insertionPoint = lastCardParentDiv.parentNode;
+   insertionPoint.insertBefore(newLastCardTable, lastCardParentDiv);
+   insertionPoint.removeChild(lastCardParentDiv);
+
+   return;
+}
+
+if (document.readyState !== 'loading') {
+   adjustAppearance();
+} else {
+   document.addEventListener('DOMContentLoaded', adjustAppearance);
+}

--- a/src/sidebar_set_contents.py
+++ b/src/sidebar_set_contents.py
@@ -16,6 +16,32 @@ from .helper_functions import (
 )
 from .revlog import revlog_data_mod
 
+import os
+
+def style_script_path() -> str:
+    """Returns path to the script that adjusts the last card table style
+
+    Returns
+    -------
+    string
+        The absolute path to the script
+    """
+    dir_path = os.path.dirname(__file__)
+    return os.path.join(dir_path, 'adjust_styles.js')
+
+def style_script_contents() -> str:
+    """Returns the content of a JavaScript that adjusts the last card table style
+
+    Returns
+    -------
+    string
+        The contents of the script file
+    """
+    script_path = style_script_path()
+    with open(script_path) as file:
+        data = file.read()
+    return data
+
 
 def update_contents_of_sidebar(self):
     if not self.shown:
@@ -78,6 +104,8 @@ def update_contents_of_sidebar(self):
         style = sidebar_style("styling_dark.css")
     else:
         style = sidebar_style("styling.css")
+    # add contents of our adjustment script
+    style_adj_script = style_script_contents()
     self.web.setHtml("""
 <html>
 <head>
@@ -89,5 +117,6 @@ def update_contents_of_sidebar(self):
 <center>
 %s
 </center>
+<script>%s</script>
 </body>
-</html>""" % (style, txt))
+</html>""" % (style, txt, style_adj_script))


### PR DESCRIPTION
Creates a more consistent display in the last card pane by recreating the last card stats data table, based on the current card pane’s table format. Also applies the default styling from the first load rather than waiting for the next card to force the last card stats to display, where the links to the system CSS files are found.

Solves two issues:

1. Previously, on first launch the stats of the current card were displayed with no CSS applied because the links to the system CSS were only available once the Last Card section was loaded. Now, we provide the CSS from the Anki in the `<head>` section so it's available on first load.
2. The Current Card and Last Card were displayed differently because they came from two different sources. The Current Card's stats table is created by the add-on whereas the Last Card's stats table is derived from Anki's own stats page. This commit creates a consistent visual style by scraping all of the data from the Anki-provided stats table and building a new table from it, based on the formatting used in the Current Card stats table. Then the original Anki-provided table is removed from the DOM.

In solving issue 2 above, an arbitrary small delay had to added to allow Anki's provided js to make its own modifications to the DOM. It's a little fragile and may need to be adjusted but I couldn't think of any other signal to latch onto. I've only tested it on macOS 11.6, Intel; Anki 2.1.53, Qt6

@NSBum - aka u/OjisanSeiuchi

### First load, no CSS 

<img width="1040" alt="First load showing no CSS applied" src="https://user-images.githubusercontent.com/10759859/192174000-eb84abcd-bca7-418f-bd79-f072bc11e800.png">

### After the above issues addressed

<img width="1270" alt="Visual style corrected" src="https://user-images.githubusercontent.com/10759859/192174108-7baa9998-c1f2-4500-98b4-196bf2917d91.png">

### And night mode is unaffected

<img width="1225" alt="Night mode unaffected" src="https://user-images.githubusercontent.com/10759859/192174170-b080f64c-1d05-4faa-82dc-5a7bacc03626.png">

